### PR TITLE
feat: add support for Laravel 12.x and update compatibility in compos…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-comments` will be documented in this file.
 
+## Unreleased
+
+* Add support for Laravel 12.x
+
 ## v1.0.0 - 2024-03-12
 
 * Support for Laravel 11.x

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 This package provides an incredibly simple comment system for your Laravel applications.
 
+> **Compatibility:** This package supports Laravel 11 and Laravel 12.
+
 > If you're looking for a package with UI components, I highly recommend using [Spatie's `laravel-comments`](https://laravel-comments.com/) package which comes with Livewire support out of the box.
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^11.0",
-        "illuminate/database": "^11.0",
+        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/database": "^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.16.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
         "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.0|^10.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.0|^11.0",
         "spatie/laravel-ray": "^1.35"
     },
     "autoload": {


### PR DESCRIPTION
This pull request introduces support for Laravel 12.x in the `laravel-comments` package. The changes ensure compatibility with the latest Laravel version and update relevant documentation and dependencies.

### Laravel 12.x Compatibility:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L20-R33): Updated the `illuminate/contracts`, `illuminate/database`, and `orchestra/testbench` dependencies to support both Laravel 11.x and 12.x. Additionally, updated `phpunit/phpunit` to support version 11.x alongside 10.x.

### Documentation Updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R8): Added an entry under "Unreleased" to document the addition of Laravel 12.x support.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10-R11): Added a compatibility note indicating that the package supports Laravel 11 and Laravel 12
composer.json and README files.